### PR TITLE
Update makefile to work with OTP 26

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,9 +5,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 
 PROJECT := dirent
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s erlang halt)
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)])." -s erlang halt)
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)])." -s erlang halt)
 ERL_VERSION := $(shell erl -noshell -eval 'io:fwrite("~s\n", [erlang:system_info(otp_release)]).' -s erlang halt)
 
 C_SRC_DIR = $(CURDIR)


### PR DESCRIPTION
The updated lines fail in OTP 26 and later due to a race condition with `-s init stop`, see: https://github.com/erlang/otp/issues/6916#issuecomment-1443361227.

* Moved shutdown flags to the end of each line to resolve the race condition.
* Replaced `-s init stop` with `-s erlang halt` for faster shutdown.
